### PR TITLE
Changes:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
 - 1.6.2
 install:
 - go get -u github.com/kardianos/govendor
+- go get -u golang.org/x/oauth2
+- go get -u github.com/google/go-github/github
 - govendor sync
 script: go test ./...
 deploy:

--- a/main.go
+++ b/main.go
@@ -3,7 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-github/github"
 	"github.com/julienschmidt/httprouter"
+	"golang.org/x/oauth2"
+	githuboauth "golang.org/x/oauth2/github"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -24,6 +27,20 @@ type Plugin struct {
 	Issues      int    `json:"issues_count"`
 }
 
+// Creates the oauthConf variable.
+// To replicate: Create developer oauth application at github.com/setting/applications
+// ClientID and ClientSecret are supplied by github after creating the developer oauth application token.
+// This gives us access to their username:email and repo information.
+var (
+	oauthConf = &oauth2.Config{
+		ClientID:     "2502f1186a0b687847a8",
+		ClientSecret: "3269896c65db7131a0bd473b1361777234aa4b86",
+		Scopes:       []string{"user:email", "repo"},
+		Endpoint:     githuboauth.Endpoint,
+	}
+	oauthStateString = "asdfghjkl"
+)
+
 func Filter(vs []Plugin, f func(Plugin) bool) []Plugin {
 	vsf := make([]Plugin, 0)
 	for _, v := range vs {
@@ -35,13 +52,56 @@ func Filter(vs []Plugin, f func(Plugin) bool) []Plugin {
 }
 
 func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	fmt.Fprintf(w, `Snap Plugin API Server:
+	// This is our main page. We may want to update it to look a bit spiffier.
+	htmlOut := `Snap Plugin API Server:
 
-/plugins
-/plugins/collector
-/plugins/processor
-/plugins/publisher
-/plugin/:name`)
+<p>Log in with <a href="/login">Github</a> for access to external plugins.</p>
+
+<p>/plugins</p>
+<p>/plugins/collector</p>
+<p>/plugins/processor</p>
+<p>/plugins/publisher</p>
+<p>/plugin/:name</p>`
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(htmlOut))
+}
+
+// Logs external users into Github in order to grant us access to their repo information.
+func loginToGitHub(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	url := oauthConf.AuthCodeURL(oauthStateString, oauth2.AccessTypeOnline)
+	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+
+}
+
+// Returns us from github after successful OAuth request.
+// TODO: Perhaps this is where we could add any of their snap plugins to our list?
+func callBack(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	state := r.FormValue("state")
+	// TODO: if the State string is incorrect we should probably handle that.
+	if state != oauthStateString {
+		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		return
+	}
+
+	code := r.FormValue("code")
+	token, err := oauthConf.Exchange(oauth2.NoContext, code)
+	// TODO: We might want to do some error handling?
+	if err != nil {
+		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		return
+	}
+
+	oauthClient := oauthConf.Client(oauth2.NoContext, token)
+	client := github.NewClient(oauthClient)
+	_, _, err = client.Users.Get("")
+	// TODO: And again - Error Handling.
+	if err != nil {
+		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		return
+	}
+
+	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
 func ListPlugin(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -78,6 +138,8 @@ func main() {
 	router.GET("/plugins", ListPlugins)
 	router.GET("/plugins/:type", ListPlugins)
 	router.GET("/plugin/:name", ListPlugin)
+	router.GET("/login", loginToGitHub)
+	router.GET("/snap_github_cb", callBack)
 
 	var port = os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
- Added Github OAuth2 Support
    - New Imports:
      golang.org/x/oauth2,
      github/google/go-github/github,
      githuboauth
    - New functions:
      loginToGitHub - redirects to github for OAuth2 authorization.
      callBack - callBack from github, needed to route back from github.
    - New Variable:
      oauthConf - An oauth2 object that handles most of the oauth stuff.
    - New Main Calls:
      router.GET(")login", loginToGitHub) - Creates the webpage for
      login.
      router.GET("/snap_github_cb", callBack) - Creates the webpage for
      callback.